### PR TITLE
ensure go vet works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /manifests.local/
+/migrator

--- a/pkg/trigger/discovery_handler_test.go
+++ b/pkg/trigger/discovery_handler_test.go
@@ -22,13 +22,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
-	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clients/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
+	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clients/clientset/fake"
 )
 
 func staleStorageState() *v1alpha1.StorageState {
@@ -40,7 +41,7 @@ func staleStorageState() *v1alpha1.StorageState {
 			Resource: v1alpha1.GroupResource{Resource: "pods"},
 		},
 		Status: v1alpha1.StorageStateStatus{
-			LastHeartbeatTime: metav1.Time{metav1.Now().Add(-3 * discoveryPeriod)},
+			LastHeartbeatTime: metav1.Time{Time: metav1.Now().Add(-3 * discoveryPeriod)},
 		},
 	}
 }
@@ -56,7 +57,7 @@ func freshStorageState() *v1alpha1.StorageState {
 		Status: v1alpha1.StorageStateStatus{
 			CurrentStorageVersionHash:     "newhash",
 			PersistedStorageVersionHashes: []string{"newhash"},
-			LastHeartbeatTime:             metav1.Time{metav1.Now().Add(-1 * discoveryPeriod)},
+			LastHeartbeatTime:             metav1.Time{Time: metav1.Now().Add(-1 * discoveryPeriod)},
 		},
 	}
 }
@@ -72,7 +73,7 @@ func freshStorageStateWithOldHash() *v1alpha1.StorageState {
 		Status: v1alpha1.StorageStateStatus{
 			CurrentStorageVersionHash:     "oldhash",
 			PersistedStorageVersionHashes: []string{"oldhash"},
-			LastHeartbeatTime:             metav1.Time{metav1.Now().Add(-1 * discoveryPeriod)},
+			LastHeartbeatTime:             metav1.Time{Time: metav1.Now().Add(-1 * discoveryPeriod)},
 		},
 	}
 }


### PR DESCRIPTION
Fixes:
```
pkg/trigger/discovery_handler_test.go:43:23: github.com/kubernetes-sigs/kube-storage-version-migrator/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.Time composite literal uses unkeyed fields
pkg/trigger/discovery_handler_test.go:59:35: github.com/kubernetes-sigs/kube-storage-version-migrator/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.Time composite literal uses unkeyed fields
pkg/trigger/discovery_handler_test.go:75:35: github.com/kubernetes-sigs/kube-storage-version-migrator/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.Time composite literal uses unkeyed fields
```