### PR TITLE
Bug 1947801: bump(build-machinery-go)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/onsi/ginkgo v1.11.0
-	github.com/openshift/build-machinery-go v0.0.0-20210422090345-375a97024506
+	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -365,8 +365,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
-github.com/openshift/build-machinery-go v0.0.0-20210422090345-375a97024506 h1:Eml1TpcFDYO/nhnQjfUyDNjuudtaBehu6sgui4x+8nA=
-github.com/openshift/build-machinery-go v0.0.0-20210422090345-375a97024506/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e h1:F7rBobgSjtYL3/zsgDUjlTVx3Z06hdgpoldpDcn7jzc=
+github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
@@ -1,20 +1,18 @@
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
 .empty-golang-versions-files:
-	@mkdir -p "$(PERMANENT_TMP)"
 	@rm -f "$(PERMANENT_TMP)/golang-versions" "$(PERMANENT_TMP)/named-golang-versions"
-	@touch "$(PERMANENT_TMP)/golang-versions" "$(PERMANENT_TMP)/named-golang-versions"
 .PHONE: .empty-golang-versions-files
 
 verify-golang-versions:
 	@if [ -f "$(PERMANENT_TMP)/golang-versions" ]; then \
 		LINES=$$(cat "$(PERMANENT_TMP)/golang-versions" | sort | uniq | wc -l); \
-  		if [ $${LINES} -gt 1 ]; then \
+			if [ $${LINES} -gt 1 ]; then \
 			echo "Golang version mismatch:"; \
 			cat "$(PERMANENT_TMP)/named-golang-versions" | sort | sed 's/^/- /'; \
 			false; \
-    	fi; \
-    fi
+		fi; \
+	fi
 .PHONY: verify-golang-versions
 
 # $1 - filename (symbolic, used as postfix in Makefile target)
@@ -22,12 +20,12 @@ verify-golang-versions:
 define verify-golang-version-reference-internal
 verify-golang-versions-$(1): .empty-golang-versions-files
 verify-golang-versions-$(1):
+	@mkdir -p "$(PERMANENT_TMP)"
 	@echo "$(1): $(2)" >> "$(PERMANENT_TMP)/named-golang-versions"
 	@echo "$(2)" >> "$(PERMANENT_TMP)/golang-versions"
 .PHONY: verify-golang-versions-$(1)
 
 verify-golang-versions: verify-golang-versions-$(1)
-.PHONY: verify-golang-versions
 endef
 
 # $1 - filename (symbolic, used as postfix in Makefile target)
@@ -42,26 +40,18 @@ $(call verify-golang-version-reference,$(1),$(shell grep "AS builder" "$(1)" | s
 endef
 
 define verify-go-mod-golang-version
-$(call verify-golang-version-reference,go.mod,$(shell grep -e 'go [[:digit:]]*\.[[:digit:]]*' go.mod | sed 's/go //'))
+$(call verify-golang-version-reference,go.mod,$(shell grep -e 'go [[:digit:]]*\.[[:digit:]]*' go.mod 2>/dev/null | sed 's/go //'))
 endef
 
 define verify-buildroot-golang-version
-$(call verify-golang-version-reference,.ci-operator.yaml,$(shell grep -e 'tag: golang-[[:digit:]]*\.[[:digit:]]*' .ci-operator.yaml | sed 's/.*tag: golang-//'))
+$(call verify-golang-version-reference,.ci-operator.yaml,$(shell grep -e 'tag: .*golang-[[:digit:]]*\.[[:digit:]]' .ci-operator.yaml 2>/dev/null | sed 's/.*golang-\([[:digit:]][[:digit:]]*.[[:digit:]][[:digit:]]*\).*/\1/'))
 endef
 
 # $1 - optional Dockerfile filename (symbolic, used as postfix in Makefile target)
 define verify-golang-versions
-ifeq (,$(wildcard ./go.mod))
-$(call verify-go-mod-golang-version)
-endif
-ifeq (,$(wildcard ./.ci-operator.yaml))
-ifneq ($(shell grep 'build_root_image:' .ci-operator.yaml),)
-$(call verify-buildroot-golang-version)
-endif
-endif
-ifneq ($(1),)
-$(call verify-Dockerfile-builder-golang-version,$(1))
-endif
+$(if $(1),$(call verify-Dockerfile-builder-golang-version,$(1))) \
+$(if $(wildcard ./.ci-operator.yaml),$(if $(shell grep 'build_root_image:' .ci-operator.yaml 2>/dev/null),$(call verify-buildroot-golang-version))) \
+$(if $(wildcard ./go.mod),$(call verify-go-mod-golang-version))
 endef
 
 # We need to be careful to expand all the paths before any include is done

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -98,7 +98,7 @@ github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
-# github.com/openshift/build-machinery-go v0.0.0-20210422090345-375a97024506
+# github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 ## explicit
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Get fix for golang 1.16 detection with standardized image name for https://github.com/openshift/kubernetes-kube-storage-version-migrator/pull/174, follow-up of https://github.com/openshift/kubernetes-kube-storage-version-migrator/pull/173.