### PR TITLE
Bug 1947801: UPSTREAM: 93: Move metadata.name description into yaml-patch to move around inability of kubebuilder to express that

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /manifests.local/
 /migrator
+_output

--- a/manifests/storage_state_crd.yaml
+++ b/manifests/storage_state_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: storagestates.migration.k8s.io
   annotations:
-    "api-approved.kubernetes.io": "https://github.com/kubernetes/enhancements/pull/747"
+    api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/747
+  name: storagestates.migration.k8s.io
 spec:
   group: migration.k8s.io
   names:
@@ -11,18 +11,13 @@ spec:
     listKind: StorageStateList
     plural: storagestates
     singular: storagestate
-  scope: Cluster
   preserveUnknownFields: false
+  scope: Cluster
   versions:
   - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: The state of the storage of a specific resource.
-        type: object
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -35,15 +30,16 @@ spec:
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
-            description: The name must be "<.spec.resource.resouce>.<.spec.resource.group>".
+            properties:
+              name:
+                description: name must be "<.spec.resource.resouce>.<.spec.resource.group>".
+                type: string
             type: object
           spec:
             description: Specification of the storage state.
-            type: object
             properties:
               resource:
                 description: The resource this storageState is about.
-                type: object
                 properties:
                   group:
                     description: The name of the group.
@@ -51,9 +47,10 @@ spec:
                   resource:
                     description: The name of the resource.
                     type: string
+                type: object
+            type: object
           status:
             description: Status of the storage state.
-            type: object
             properties:
               currentStorageVersionHash:
                 description: The hash value of the current storage version, as shown
@@ -64,8 +61,8 @@ spec:
                 description: LastHeartbeatTime is the last time the storage migration
                   triggering controller checks the storage version hash of this resource
                   in the discovery document and updates this field.
-                type: string
                 format: date-time
+                type: string
               persistedStorageVersionHashes:
                 description: The hash values of storage versions that persisted instances
                   of spec.resource might still be encoded in. "Unknown" is a valid
@@ -76,6 +73,12 @@ spec:
                   this field is refined to only contain the currentStorageVersionHash.
                   Once the apiserver has changed the storage version, the new storage
                   version is appended to the list.
-                type: array
                 items:
                   type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/storage_state_crd.yaml-patch
+++ b/manifests/storage_state_crd.yaml-patch
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/versions/name=v1alpha1/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      description: name must be "<.spec.resource.resouce>.<.spec.resource.group>".
+      type: string

--- a/pkg/apis/migration/v1alpha1/types.go
+++ b/pkg/apis/migration/v1alpha1/types.go
@@ -120,7 +120,6 @@ type StorageVersionMigrationList struct {
 // The state of the storage of a specific resource.
 type StorageState struct {
 	metav1.TypeMeta `json:",inline"`
-	// The name must be "<.spec.resource.resouce>.<.spec.resource.group>".
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the storage state.


### PR DESCRIPTION
Backport of https://github.com/kubernetes-sigs/kube-storage-version-migrator/pull/93.