### PR TITLE
OCPBUGS-45383: Updating ose-kube-storage-version-migrator-container i…

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kube-storage-version-migrator
 
-go 1.22
+go 1.23
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/kube-storage-version-migrator
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder /go/src/github.com/kubernetes-sigs/kube-storage-version-migrator/migrator /usr/bin/


### PR DESCRIPTION
Continuation of https://github.com/openshift/kubernetes-kube-storage-version-migrator/pull/208 which has not updated the go.mod to 1.23, and therefore is failing to verify