### PR TITLE
OCPBUGS-38523: Reduce the page size on list requests to the Kube API server

### DIFF
--- a/pkg/migrator/core.go
+++ b/pkg/migrator/core.go
@@ -39,7 +39,7 @@ import (
 var metadataAccessor = meta.NewAccessor()
 
 const (
-	defaultChunkLimit  = 500
+	defaultChunkLimit  = 100
 	defaultConcurrency = 1
 )
 


### PR DESCRIPTION
Reduce the page size on list requests to the Kube API server from 500 to 100. These list requests can be very expensive, and present memory issues when resources themselves are large. For situations where all resources are to be requested (like reencrypting etcd), it makes more sense to choose a smaller batch size to account for memory requirements, and is unlikely to greatly affect the time required to perform the operation.

This will need to be backported, and will be less of an issue in future versions due to https://kubernetes.io/blog/2024/12/17/kube-apiserver-api-streaming/