### PR TITLE
ART-13079: append .0 to go.mod version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kube-storage-version-migrator
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/onsi/ginkgo v1.16.5


### PR DESCRIPTION
The go.mod change is required for ART builds. http://github.com/openshift/build-machinery-go will need to be updated to permit 1.y.z and 1.y matches before the verify job will succeed