### PR TITLE
[ART-13123] append .0 to go.mod version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module sigs.k8s.io/kube-storage-version-migrator
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/onsi/ginkgo v1.16.5
-	github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
+	github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,7 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -191,6 +192,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -224,11 +226,13 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
+github.com/onsi/ginkgo/v2 v2.9.1/go.mod h1:FEcmzVcCHl+4o9bQZVab+4dC9+j+91t2FHSzmGAPfuo=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
-github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533 h1:mh3ZYs7kPIIe3UUY6tJcTExmtjnXXUu0MrBuK2W/Qvw=
-github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
+github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c h1:gJvhduWIrpzoUTwrJjjeul+hGETKkhRhEZosBg/X3Hg=
+github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -263,6 +267,7 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -386,6 +391,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/vendor/github.com/openshift/build-machinery-go/.ci-operator.yaml
+++ b/vendor/github.com/openshift/build-machinery-go/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.17-openshift-4.10
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/vendor/github.com/openshift/build-machinery-go/OWNERS
+++ b/vendor/github.com/openshift/build-machinery-go/OWNERS
@@ -1,9 +1,9 @@
 reviewers:
-  - sttts
-  - mfojtik
-  - soltysh
   - 2uasimojo
+  - benluddy
+  - jsafrane
+  - sanchezl
 approvers:
-  - sttts
-  - mfojtik
-  - soltysh
+  - benluddy
+  - jsafrane
+  - sanchezl

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -13,6 +13,7 @@ image-ocp-openshift-apiserver-operator
 images
 telepresence
 test
+test-operator-integration
 test-unit
 update
 update-bindata
@@ -21,6 +22,7 @@ update-deps-overrides
 update-generated
 update-gofmt
 update-profile-manifests
+update-test-operator-integration
 verify
 verify-bindata
 verify-codegen

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/verify-update.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/verify-update.mk
@@ -3,11 +3,12 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 )
 
 go_files_count :=$(words $(GO_FILES))
+chunk_size :=1000
 
 verify-gofmt:
 	$(info Running `$(GOFMT) $(GOFMT_FLAGS)` on $(go_files_count) file(s).)
 	@TMP=$$( mktemp ); \
-	$(GOFMT) $(GOFMT_FLAGS) $(GO_FILES) | tee $${TMP}; \
+	find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) | tee $${TMP}; \
 	if [ -s $${TMP} ]; then \
 		echo "$@ failed - please run \`make update-gofmt\`"; \
 		exit 1; \
@@ -16,7 +17,7 @@ verify-gofmt:
 
 update-gofmt:
 	$(info Running `$(GOFMT) $(GOFMT_FLAGS) -w` on $(go_files_count) file(s).)
-	@$(GOFMT) $(GOFMT_FLAGS) -w $(GO_FILES)
+	@find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) -w
 .PHONY: update-gofmt
 
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
@@ -43,7 +43,7 @@ $(call verify-golang-version-reference,$(1),$(shell grep "AS builder" "$(1)" | s
 endef
 
 define verify-go-mod-golang-version
-$(call verify-golang-version-reference,go.mod,$(shell grep -e 'go [[:digit:]]*\.[[:digit:]]*' go.mod 2>/dev/null | sed 's/go //'))
+$(call verify-golang-version-reference,go.mod,$(shell grep -e 'go [[:digit:]]*\.[[:digit:]]*' go.mod 2>/dev/null | sed 's/go \([[:digit:]][[:digit:]]*.[[:digit:]][[:digit:]]*\).*/\1/'))
 endef
 
 define verify-buildroot-golang-version

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
@@ -3,6 +3,26 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 	../../lib/tmp.mk \
 )
 
+##############
+# DEPRECATED #
+##############
+# This utility is hard to maintain due to the need to continuously build and release binaries for
+# multiple platforms and versions. Instead it is recommended that you:
+# - Vendor the sigs.k8s.io/controller-tools repository.
+# - Write a local rule to (lazily) build the controller-gen binary from the vendored repo.
+# For example:
+#
+# CONTROLLER_GEN_SRC := $(shell realpath vendor/sigs.k8s.io/controller-tools/cmd/controller-gen)
+# CONTROLLER_GEN := $(shell go list -f '{{.Target}}' $(CONTROLLER_GEN_SRC))
+# $(CONTROLLER_GEN): $(CONTROLLER_GEN_SRC)
+# 	go install $(CONTROLLER_GEN_SRC)
+#
+# This allows you to upgrade versions simply by revendoring controller-tools:
+# - Bump the semver in your go.mod
+# - go mod tidy
+# - go mod vendor
+##############
+
 # NOTE: The release binary specified here needs to be built properly so that
 # `--version` works correctly. Just using `go build` will result in it
 # reporting `(devel)`. To build for a given platform:

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
@@ -7,15 +7,21 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 # make images IMAGE_BUILD_EXTRA_FLAGS='-mount ~/projects/origin-repos/4.2/:/etc/yum.repos.d/'
 IMAGE_BUILD_DEFAULT_FLAGS ?=--allow-pull
 IMAGE_BUILD_EXTRA_FLAGS ?=
+IMAGE_BUILD_BUILDER ?= imagebuilder
 
 # $1 - target name
 # $2 - image ref
 # $3 - Dockerfile path
 # $4 - context
+# only run ensure-imagebuilder when imagebuilder is used
 define build-image-internal
+ifeq ($(IMAGE_BUILD_BUILDER),imagebuilder)
 image-$(1): ensure-imagebuilder
+else
+image-$(1):
+endif
 	$(strip \
-		imagebuilder \
+		$(IMAGE_BUILD_BUILDER) \
 		$(IMAGE_BUILD_DEFAULT_FLAGS) \
 		-t $(2)
 		-f $(3) \

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
@@ -8,8 +8,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 YQ_VERSION ?=2.4.0
 YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq-$(YQ_VERSION)
-yq_dir :=$(dir $(YQ))
-
+yq_dir =$(dir $(YQ))
 
 ensure-yq:
 ifeq "" "$(wildcard $(YQ))"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -131,8 +131,8 @@ github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
-# github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
-## explicit; go 1.13
+# github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c
+## explicit; go 1.22.0
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib


### PR DESCRIPTION
The go.mod change is required for ART builds. [http://github.com/openshift/build-machinery-go](https://github.com/openshift/build-machinery-go) will need to be updated to permit 1.y.z and 1.y matches before the verify job will succeed