### PR TITLE
WIP: Syncing Ci build root image, Dockerfile Base images and go version in go.mod with ART 4.22 stream

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.22
+  tag: rhel-9-release-golang-1.25-openshift-4.22

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kube-storage-version-migrator
 
-go 1.24.0
+go 1.25.9
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/kube-storage-version-migrator
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9-minimal
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 COPY --from=builder /go/src/github.com/kubernetes-sigs/kube-storage-version-migrator/migrator /usr/bin/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain from version 1.24 to 1.25, including corresponding updates to build and container images to ensure compatibility and leverage the latest Go runtime improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->