### PR TITLE
OCPBUGS-85280: Detect orphaned namespace objects during storage version migration

### DIFF
--- a/pkg/migrator/core.go
+++ b/pkg/migrator/core.go
@@ -205,8 +205,28 @@ func (m *migrator) migrateOneItem(ctx context.Context, item *unstructured.Unstru
 	getBeforePut := false
 	for {
 		getBeforePut, err = m.try(ctx, namespace, name, item, getBeforePut)
-		if err == nil || errors.IsNotFound(err) {
+		if err == nil {
 			return nil
+		}
+		// NotFound from Update can mean two things:
+		//  (a) the object was deleted between List and Update — safe to skip.
+		//  (b) the object still exists in etcd but its Namespace has been
+		//      fully deleted — the NamespaceLifecycle admission plugin
+		//      rejects mutations in non-existent namespaces with NotFound,
+		//      even though the object is still in storage.
+		// A GET bypasses admission and reads directly from storage,
+		// distinguishing (a) from (b).
+		if errors.IsNotFound(err) {
+			_, getErr := m.get(ctx, namespace, name)
+			if errors.IsNotFound(getErr) {
+				return nil
+			}
+			if getErr != nil {
+				return fmt.Errorf("failed to verify existence of %s/%s after update returned NotFound: %v",
+					namespace, name, getErr)
+			}
+			return fmt.Errorf("cannot migrate %s/%s: object exists in storage but namespace %q "+
+				"has been deleted", namespace, name, namespace)
 		}
 		if canRetry(err) {
 			seconds, delay := errors.SuggestsClientDelay(err)

--- a/pkg/migrator/core_test.go
+++ b/pkg/migrator/core_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -326,5 +327,66 @@ func expectCounterCount(t *testing.T, name string, labelFilter map[string]string
 				}
 			}
 		}
+	}
+}
+
+func TestMigrateOneItem_NotFoundThenGetNotFound(t *testing.T) {
+	podList := newPodList(1)
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme.Scheme, nil, &podList)
+
+	client.Fake.PrependReactor("update", "pods", func(a clitesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewNotFound(v1.Resource("pods"), "pod0")
+	})
+	client.Fake.PrependReactor("get", "pods", func(a clitesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewNotFound(v1.Resource("pods"), "pod0")
+	})
+
+	m := NewMigrator(v1.SchemeGroupVersion.WithResource("pods"), client, &progressTracker{})
+	items := toUnstructuredListOrDie(podList)
+	err := m.migrateOneItem(context.Background(), &items.Items[0])
+	if err != nil {
+		t.Errorf("expected nil error for genuinely deleted object, got: %v", err)
+	}
+}
+
+func TestMigrateOneItem_NotFoundThenGetSucceeds(t *testing.T) {
+	podList := newPodList(1)
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme.Scheme, nil, &podList)
+
+	client.Fake.PrependReactor("update", "pods", func(a clitesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewNotFound(v1.Resource("pods"), "pod0")
+	})
+	// default GET returns the object (it exists in the fake client)
+
+	m := NewMigrator(v1.SchemeGroupVersion.WithResource("pods"), client, &progressTracker{})
+	items := toUnstructuredListOrDie(podList)
+	err := m.migrateOneItem(context.Background(), &items.Items[0])
+	if err == nil {
+		t.Fatal("expected error for orphaned namespace object, got nil")
+	}
+	if !strings.Contains(err.Error(), "object exists in storage but namespace") {
+		t.Errorf("expected orphaned namespace error message, got: %v", err)
+	}
+}
+
+func TestMigrateOneItem_NotFoundThenGetError(t *testing.T) {
+	podList := newPodList(1)
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme.Scheme, nil, &podList)
+
+	client.Fake.PrependReactor("update", "pods", func(a clitesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewNotFound(v1.Resource("pods"), "pod0")
+	})
+	client.Fake.PrependReactor("get", "pods", func(a clitesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("connection refused")
+	})
+
+	m := NewMigrator(v1.SchemeGroupVersion.WithResource("pods"), client, &progressTracker{})
+	items := toUnstructuredListOrDie(podList)
+	err := m.migrateOneItem(context.Background(), &items.Items[0])
+	if err == nil {
+		t.Fatal("expected error when GET fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to verify existence") {
+		t.Errorf("expected verification error message, got: %v", err)
 	}
 }

--- a/pkg/migrator/core_test.go
+++ b/pkg/migrator/core_test.go
@@ -156,6 +156,17 @@ func TestMigrateList(t *testing.T) {
 		return false, nil, nil
 	})
 
+	client.Fake.PrependReactor("get", "pods", func(a clitesting.Action) (bool, runtime.Object, error) {
+		ga, ok := a.(clitesting.GetAction)
+		if !ok {
+			t.Fatalf("expected GetAction")
+		}
+		if ga.GetName() == "pod53" {
+			return true, nil, errors.NewNotFound(v1.Resource("pods"), "pod53")
+		}
+		return false, nil, nil
+	})
+
 	migrator := NewMigrator(v1.SchemeGroupVersion.WithResource("pods"), client, &progressTracker{})
 	migratorError := migrator.migrateList(toUnstructuredListOrDie(podList))
 
@@ -166,21 +177,25 @@ func TestMigrateList(t *testing.T) {
 	for _, a := range actions {
 		namespace, verb := a.GetNamespace(), a.GetVerb()
 		var name string
-		if verb != "update" {
+		switch verb {
+		case "update":
+			ua, ok := a.(clitesting.UpdateAction)
+			if !ok {
+				t.Fatalf("expected UpdateAction")
+			}
+			obj := ua.GetObject()
+			var err error
+			name, err = metadataAccessor.Name(obj)
+			if err != nil {
+				t.Fatal(err)
+			}
+			nsSet.Insert(namespace)
+			podSet.Insert(name)
+		case "get":
+			// GET requests are expected after NotFound on Update (orphan probe)
+		default:
 			t.Errorf("unexpected %q request %v", verb, a)
 		}
-		ua, ok := a.(clitesting.UpdateAction)
-		if !ok {
-			t.Fatalf("expected UpdateAction")
-		}
-		obj := ua.GetObject()
-		var err error
-		name, err = metadataAccessor.Name(obj)
-		if err != nil {
-			t.Fatal(err)
-		}
-		nsSet.Insert(namespace)
-		podSet.Insert(name)
 	}
 	for i := 0; i < 100; i++ {
 		if !nsSet.Has(fmt.Sprintf("namespace%d", i)) {


### PR DESCRIPTION
## Summary

- When a namespace is fully deleted but child objects remain in etcd, the NamespaceLifecycle admission plugin rejects Update requests with NotFound. The migrator previously treated all NotFound errors as "object deleted, safe to skip," causing migration to report success even though orphaned objects were never re-written to storage.
- After receiving NotFound on Update, the migrator now issues a GET (which bypasses admission and reads directly from storage) to distinguish genuinely deleted objects from orphans in deleted namespaces. If the object still exists, migration is failed with an actionable error message.

Bug: https://issues.redhat.com/browse/OCPBUGS-85280

Companion library-go fix: https://github.com/openshift/library-go/pull/2364

## Test plan

- [x] `TestMigrateOneItem_NotFoundThenGetNotFound` — object genuinely deleted between List and Update, migration skips it (no error)
- [x] `TestMigrateOneItem_NotFoundThenGetSucceeds` — object exists but namespace is deleted (orphan), migration returns error
- [x] `TestMigrateOneItem_NotFoundThenGetError` — GET fails with transient error, migration returns verification error
- [x] `TestMigrateList` — existing integration test updated with GET reactor for genuinely deleted pod
- [ ] `go test ./pkg/migrator/... -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration behavior when an item update reports it wasn’t found.
  * Added an additional verification step to confirm whether the item is truly deleted before skipping migration.
  * Returns clearer outcomes for cases where the item still exists but its namespace is gone, or when verification fails.
* **Tests**
  * Added coverage for the update-then-verification scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->